### PR TITLE
fix: pass GitHub and Azure DevOps PATs to Discord bot container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,6 +219,11 @@ services:
       - S3_ACCESS_KEY=${S3_ACCESS_KEY:-}
       - S3_SECRET_KEY=${S3_SECRET_KEY:-}
       - S3_REGION=${S3_REGION:-}
+      # GitHub integration
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      # Azure DevOps integration
+      - AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG:-}
+      - AZURE_DEVOPS_PAT=${AZURE_DEVOPS_PAT:-}
       # General
       - SKIP_PROFILE_LOAD=true
       - LOG_LEVEL=${LOG_LEVEL:-INFO}


### PR DESCRIPTION
The GITHUB_TOKEN, AZURE_DEVOPS_ORG, and AZURE_DEVOPS_PAT environment
variables were missing from the discord-bot service configuration,
preventing the GitHub and Azure DevOps tools from working in Docker.