### PR TITLE
Migrate Discord library from discord.py to pycord

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ imessage-reader = "^0.6.1"
 httpx = "^0.28.0"  # Async HTTP client for web search
 
 # Discord bot
-"discord.py" = "^2.4.0"
+py-cord = "^2.6.1"
 
 # Docker code execution sandbox
 docker = "^7.0.0"


### PR DESCRIPTION
Replace discord.py 2.4.0 with py-cord 2.6.1+ for better maintained Discord library. Pycord maintains API compatibility with discord.py so no code changes are required - same import namespace works.