### PR TITLE
Fix: Tool model now respects tier prefixes (!high, !mid, !low)

### DIFF
--- a/clara_core/llm.py
+++ b/clara_core/llm.py
@@ -33,6 +33,9 @@ DEFAULT_TIER: ModelTier = "mid"
 
 # Tool calling configuration
 TOOL_FORMAT = os.getenv("TOOL_FORMAT", "openai").lower()
+# DEPRECATED: TOOL_MODEL env var is no longer used.
+# Tools now always use tier-based model selection to respect !high, !mid, !low prefixes.
+# This constant is kept for backwards compatibility but has no effect.
 TOOL_MODEL = os.getenv("TOOL_MODEL", "")
 
 # Default models per provider per tier
@@ -528,16 +531,14 @@ def _convert_messages_to_claude_format(messages: list[dict]) -> list[dict]:
 def _get_tool_model(tier: ModelTier | None = None) -> str:
     """Get the model to use for tool calling.
 
-    Checks TOOL_MODEL env var first, then falls back to tier-based selection.
+    Always uses tier-based model selection to respect !high, !mid, !low prefixes.
+    The TOOL_MODEL env var is deprecated and ignored.
 
     Args:
         tier: Optional tier override. If None, uses default tier.
     """
-    # Explicit TOOL_MODEL takes priority
-    if tool_model := os.getenv("TOOL_MODEL"):
-        return tool_model
-
-    # Use tier-based model selection
+    # Always use tier-based model selection
+    # This ensures !high, !mid, !low prefixes are respected for tool calls
     provider = os.getenv("LLM_PROVIDER", "openrouter").lower()
     effective_tier = tier or get_current_tier()
     return get_model_for_tier(effective_tier, provider)


### PR DESCRIPTION
## Summary
Fixes #15 - Tool model tier override not working

## Problem
When users use `!high`, `!mid`, or `!low` prefixes, the main chat response uses the correct tier model, but tool calls continue to use whatever is set in `TOOL_MODEL` env var, ignoring the tier override.

## Solution
Modified `_get_tool_model()` in `clara_core/llm.py` to **always** use tier-based model selection instead of checking `TOOL_MODEL` env var first.

### Changes
- **`clara_core/llm.py`**:
  - Removed the `TOOL_MODEL` env var priority check in `_get_tool_model()`
  - Now always uses `get_model_for_tier(effective_tier, provider)` 
  - Added deprecation comment for the `TOOL_MODEL` constant (kept for backwards compat)

### Before
```python
def _get_tool_model(tier: ModelTier | None = None) -> str:
    # Explicit TOOL_MODEL takes priority  ← THIS WAS THE BUG
    if tool_model := os.getenv("TOOL_MODEL"):
        return tool_model
    # ... tier-based fallback
```

### After
```python
def _get_tool_model(tier: ModelTier | None = None) -> str:
    # Always use tier-based model selection
    # This ensures !high, !mid, !low prefixes are respected for tool calls
    provider = os.getenv("LLM_PROVIDER", "openrouter").lower()
    effective_tier = tier or get_current_tier()
    return get_model_for_tier(effective_tier, provider)
```

## Testing
- `!high what is 2+2` → Uses Opus for both chat AND tool calls
- `!low what is 2+2` → Uses Haiku for both chat AND tool calls
- Default (no prefix) → Uses mid-tier Sonnet for both