### PR TITLE
feat: add Google Workspace integration (Sheets, Drive, Docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,42 @@ Clara can interact with Azure DevOps projects, repos, work items, and pipelines:
 - `ado_search_code` - Search code across repos
 - `ado_list_iterations` / `ado_list_team_iterations` - View sprints/iterations
 
+### Google Workspace Integration (Discord Bot)
+Clara can interact with Google Sheets, Drive, and Docs using per-user OAuth 2.0:
+- `GOOGLE_CLIENT_ID` - OAuth 2.0 client ID from Google Cloud Console
+- `GOOGLE_CLIENT_SECRET` - OAuth 2.0 client secret
+- `GOOGLE_REDIRECT_URI` - Callback URL (e.g., https://your-app.up.railway.app/oauth/google/callback)
+
+**Connection Tools** (users must connect before using other tools):
+- `google_connect` - Generate OAuth URL to connect Google account
+- `google_status` - Check if Google account is connected
+- `google_disconnect` - Disconnect Google account
+
+**Google Sheets Tools:**
+- `google_sheets_create` - Create a new spreadsheet
+- `google_sheets_read` - Read data from a range (A1 notation)
+- `google_sheets_write` - Write data to a range
+- `google_sheets_append` - Append rows to a sheet
+- `google_sheets_list` - List user's spreadsheets
+
+**Google Drive Tools:**
+- `google_drive_list` - List files with optional query
+- `google_drive_upload` - Upload text content as a file
+- `google_drive_download` - Download file content
+- `google_drive_create_folder` - Create a folder
+- `google_drive_share` - Share a file with someone
+
+**Google Docs Tools:**
+- `google_docs_create` - Create a new document
+- `google_docs_read` - Read document content
+- `google_docs_write` - Append text to a document
+
+**Setup:**
+1. Create OAuth 2.0 credentials in Google Cloud Console
+2. Enable Google Sheets, Drive, and Docs APIs
+3. Add your Railway URL to "Authorized redirect URIs": `https://your-app.up.railway.app/oauth/google/callback`
+4. Set the environment variables above
+
 ### Claude Code Integration (Discord Bot)
 Clara can delegate complex coding tasks to Claude Code, an autonomous AI coding agent.
 

--- a/db/models.py
+++ b/db/models.py
@@ -96,3 +96,19 @@ class LogEntry(Base):
     extra_data = Column(Text, nullable=True)  # JSON for additional context
     user_id = Column(String, nullable=True, index=True)
     session_id = Column(String, nullable=True, index=True)
+
+
+class GoogleOAuthToken(Base):
+    """OAuth 2.0 tokens for Google Workspace integration (per-user)."""
+
+    __tablename__ = "google_oauth_tokens"
+
+    id = Column(String, primary_key=True, default=gen_uuid)
+    user_id = Column(String, nullable=False, unique=True, index=True)
+    access_token = Column(Text, nullable=False)
+    refresh_token = Column(Text, nullable=True)
+    token_type = Column(String, default="Bearer")
+    expires_at = Column(DateTime, nullable=True)
+    scopes = Column(Text, nullable=True)  # JSON array of granted scopes
+    created_at = Column(DateTime, default=utcnow)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -2326,6 +2326,134 @@ def health_check():
     }
 
 
+# ============== Google OAuth Endpoints ==============
+
+
+@monitor_app.get("/oauth/google/callback", response_class=HTMLResponse)
+async def google_oauth_callback(
+    code: str | None = None, state: str | None = None, error: str | None = None
+):
+    """Handle Google OAuth callback - exchange code for tokens."""
+    from tools.google_oauth import (
+        decode_state,
+        exchange_code_for_tokens,
+        is_configured,
+    )
+
+    if not is_configured():
+        return _oauth_error_html("Google OAuth not configured on this server.")
+
+    if error:
+        return _oauth_error_html(f"Google authorization denied: {error}")
+
+    if not code or not state:
+        return _oauth_error_html("Missing authorization code or state.")
+
+    try:
+        user_id = decode_state(state)
+        await exchange_code_for_tokens(code, user_id)
+        return _oauth_success_html()
+    except Exception as e:
+        logger.error(f"Google OAuth error: {e}")
+        return _oauth_error_html(f"Failed to connect: {e}")
+
+
+@monitor_app.get("/oauth/google/status/{user_id}")
+def google_oauth_status(user_id: str):
+    """Check if a user has connected their Google account."""
+    from tools.google_oauth import is_configured, is_user_connected
+
+    return {
+        "configured": is_configured(),
+        "connected": is_user_connected(user_id) if is_configured() else False,
+    }
+
+
+def _oauth_success_html() -> str:
+    """HTML page for successful OAuth connection."""
+    return """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Google Connected - Clara</title>
+    <style>
+        body {
+            font-family: system-ui, sans-serif;
+            background: #1a1a2e;
+            color: #eee;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .card {
+            background: #252542;
+            padding: 40px;
+            border-radius: 12px;
+            text-align: center;
+            max-width: 400px;
+        }
+        .success { color: #43b581; font-size: 48px; margin-bottom: 20px; }
+        h1 { color: #7289da; margin-bottom: 10px; }
+        p { color: #aaa; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="success">✓</div>
+        <h1>Google Connected!</h1>
+        <p>Your Google account is now connected to Clara. You can close this window and return to Discord.</p>
+    </div>
+</body>
+</html>
+"""
+
+
+def _oauth_error_html(message: str) -> str:
+    """HTML page for OAuth error."""
+    import html
+
+    safe_message = html.escape(message)
+    return f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Connection Failed - Clara</title>
+    <style>
+        body {{
+            font-family: system-ui, sans-serif;
+            background: #1a1a2e;
+            color: #eee;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }}
+        .card {{
+            background: #252542;
+            padding: 40px;
+            border-radius: 12px;
+            text-align: center;
+            max-width: 400px;
+        }}
+        .error {{ color: #f04747; font-size: 48px; margin-bottom: 20px; }}
+        h1 {{ color: #f04747; margin-bottom: 10px; }}
+        p {{ color: #aaa; }}
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="error">✗</div>
+        <h1>Connection Failed</h1>
+        <p>{safe_message}</p>
+    </div>
+</body>
+</html>
+"""
+
+
 DASHBOARD_HTML = """
 <!DOCTYPE html>
 <html lang="en">

--- a/tools/google_oauth.py
+++ b/tools/google_oauth.py
@@ -1,0 +1,307 @@
+"""Google OAuth 2.0 helper module.
+
+Handles OAuth flow, token storage, refresh, and revocation for Google Workspace.
+Tokens are stored per-user in the database.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import UTC, datetime
+from urllib.parse import urlencode
+
+import httpx
+
+from db.connection import SessionLocal
+from db.models import GoogleOAuthToken
+
+# OAuth configuration from environment
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
+GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "")
+
+# Google OAuth endpoints
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+
+# Scopes for Google Workspace (Sheets, Drive, Docs)
+GOOGLE_SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/documents",
+]
+
+
+def is_configured() -> bool:
+    """Check if Google OAuth is configured."""
+    return bool(GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET and GOOGLE_REDIRECT_URI)
+
+
+def get_authorization_url(user_id: str) -> str:
+    """Generate OAuth authorization URL with user_id encoded in state.
+
+    Args:
+        user_id: User identifier to encode in state parameter
+
+    Returns:
+        Full authorization URL for user to visit
+    """
+    if not is_configured():
+        raise ValueError("Google OAuth not configured - check env vars")
+
+    # Encode user_id in state (base64 for URL safety)
+    state = base64.urlsafe_b64encode(user_id.encode()).decode()
+
+    params = {
+        "client_id": GOOGLE_CLIENT_ID,
+        "redirect_uri": GOOGLE_REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(GOOGLE_SCOPES),
+        "state": state,
+        "access_type": "offline",  # Get refresh token
+        "prompt": "consent",  # Always show consent to get refresh token
+    }
+
+    return f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
+
+
+def decode_state(state: str) -> str:
+    """Decode user_id from state parameter.
+
+    Args:
+        state: Base64-encoded state from callback
+
+    Returns:
+        Decoded user_id
+    """
+    return base64.urlsafe_b64decode(state.encode()).decode()
+
+
+async def exchange_code_for_tokens(code: str, user_id: str) -> dict:
+    """Exchange authorization code for access and refresh tokens.
+
+    Args:
+        code: Authorization code from callback
+        user_id: User to store tokens for
+
+    Returns:
+        Token response dict
+    """
+    if not is_configured():
+        raise ValueError("Google OAuth not configured")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "client_id": GOOGLE_CLIENT_ID,
+                "client_secret": GOOGLE_CLIENT_SECRET,
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": GOOGLE_REDIRECT_URI,
+            },
+            timeout=30.0,
+        )
+
+        if response.status_code != 200:
+            error_data = response.json() if response.text else {}
+            err = error_data.get("error_description", response.text)
+            raise ValueError(f"Token exchange failed: {err}")
+
+        token_data = response.json()
+
+    # Calculate expiry time
+    expires_in = token_data.get("expires_in", 3600)
+    expires_at = datetime.now(UTC).replace(tzinfo=None)
+    from datetime import timedelta
+
+    expires_at = expires_at + timedelta(seconds=expires_in)
+
+    # Store in database
+    with SessionLocal() as session:
+        # Check for existing token
+        existing = (
+            session.query(GoogleOAuthToken)
+            .filter(GoogleOAuthToken.user_id == user_id)
+            .first()
+        )
+
+        if existing:
+            # Update existing
+            existing.access_token = token_data["access_token"]
+            existing.refresh_token = token_data.get(
+                "refresh_token", existing.refresh_token
+            )
+            existing.token_type = token_data.get("token_type", "Bearer")
+            existing.expires_at = expires_at
+            existing.scopes = json.dumps(GOOGLE_SCOPES)
+        else:
+            # Create new
+            new_token = GoogleOAuthToken(
+                user_id=user_id,
+                access_token=token_data["access_token"],
+                refresh_token=token_data.get("refresh_token"),
+                token_type=token_data.get("token_type", "Bearer"),
+                expires_at=expires_at,
+                scopes=json.dumps(GOOGLE_SCOPES),
+            )
+            session.add(new_token)
+
+        session.commit()
+
+    return token_data
+
+
+async def get_valid_token(user_id: str) -> str | None:
+    """Get a valid access token for user, refreshing if needed.
+
+    Args:
+        user_id: User to get token for
+
+    Returns:
+        Valid access token or None if not connected
+    """
+    with SessionLocal() as session:
+        token_record = (
+            session.query(GoogleOAuthToken)
+            .filter(GoogleOAuthToken.user_id == user_id)
+            .first()
+        )
+
+        if not token_record:
+            return None
+
+        # Check if token is expired (with 5 min buffer)
+        now = datetime.now(UTC).replace(tzinfo=None)
+        from datetime import timedelta
+
+        if token_record.expires_at and token_record.expires_at < now + timedelta(
+            minutes=5
+        ):
+            # Need to refresh
+            if not token_record.refresh_token:
+                # No refresh token, user needs to re-auth
+                return None
+
+            new_access_token = await refresh_access_token(
+                user_id, token_record.refresh_token
+            )
+            return new_access_token
+
+        return token_record.access_token
+
+
+async def refresh_access_token(user_id: str, refresh_token: str) -> str | None:
+    """Refresh an expired access token.
+
+    Args:
+        user_id: User to refresh token for
+        refresh_token: Current refresh token
+
+    Returns:
+        New access token or None on failure
+    """
+    if not is_configured():
+        return None
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "client_id": GOOGLE_CLIENT_ID,
+                "client_secret": GOOGLE_CLIENT_SECRET,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            },
+            timeout=30.0,
+        )
+
+        if response.status_code != 200:
+            # Refresh failed - token might be revoked
+            return None
+
+        token_data = response.json()
+
+    # Calculate new expiry
+    expires_in = token_data.get("expires_in", 3600)
+    from datetime import timedelta
+
+    expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(
+        seconds=expires_in
+    )
+
+    # Update in database
+    with SessionLocal() as session:
+        token_record = (
+            session.query(GoogleOAuthToken)
+            .filter(GoogleOAuthToken.user_id == user_id)
+            .first()
+        )
+
+        if token_record:
+            token_record.access_token = token_data["access_token"]
+            token_record.expires_at = expires_at
+            # Refresh tokens don't change unless Google sends a new one
+            if "refresh_token" in token_data:
+                token_record.refresh_token = token_data["refresh_token"]
+            session.commit()
+
+    return token_data["access_token"]
+
+
+async def revoke_token(user_id: str) -> bool:
+    """Revoke tokens and delete from database.
+
+    Args:
+        user_id: User to revoke tokens for
+
+    Returns:
+        True if revoked successfully
+    """
+    with SessionLocal() as session:
+        token_record = (
+            session.query(GoogleOAuthToken)
+            .filter(GoogleOAuthToken.user_id == user_id)
+            .first()
+        )
+
+        if not token_record:
+            return True  # Already disconnected
+
+        # Try to revoke with Google
+        async with httpx.AsyncClient() as client:
+            # Revoke refresh token (also invalidates access token)
+            token_to_revoke = token_record.refresh_token or token_record.access_token
+            await client.post(
+                GOOGLE_REVOKE_URL,
+                params={"token": token_to_revoke},
+                timeout=30.0,
+            )
+            # Ignore response - we delete locally regardless
+
+        # Delete from database
+        session.delete(token_record)
+        session.commit()
+
+    return True
+
+
+def is_user_connected(user_id: str) -> bool:
+    """Check if user has connected their Google account.
+
+    Args:
+        user_id: User to check
+
+    Returns:
+        True if user has stored tokens
+    """
+    with SessionLocal() as session:
+        token_record = (
+            session.query(GoogleOAuthToken)
+            .filter(GoogleOAuthToken.user_id == user_id)
+            .first()
+        )
+        return token_record is not None

--- a/tools/google_workspace.py
+++ b/tools/google_workspace.py
@@ -1,0 +1,945 @@
+"""Google Workspace tools (Sheets, Drive, Docs).
+
+Provides integration with Google Workspace APIs via per-user OAuth.
+Users must connect their Google account before using these tools.
+
+Requires env vars: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from ._base import ToolContext, ToolDef
+from .google_oauth import (
+    get_authorization_url,
+    get_valid_token,
+    is_configured,
+    is_user_connected,
+    revoke_token,
+)
+
+MODULE_NAME = "google_workspace"
+MODULE_VERSION = "1.0.0"
+
+SYSTEM_PROMPT = """
+## Google Workspace Integration
+You can interact with Google Sheets, Drive, and Docs for connected users.
+
+**Connection Tools:**
+- `google_connect` - Generate OAuth URL to connect Google account
+- `google_status` - Check if user's Google account is connected
+- `google_disconnect` - Disconnect Google account
+
+**Google Sheets:**
+- `google_sheets_create` - Create a new spreadsheet
+- `google_sheets_read` - Read data from a range (A1 notation)
+- `google_sheets_write` - Write data to a range
+- `google_sheets_append` - Append rows to a sheet
+- `google_sheets_list` - List user's spreadsheets
+
+**Google Drive:**
+- `google_drive_list` - List files with optional query
+- `google_drive_upload` - Upload text content as a file
+- `google_drive_download` - Download file content
+- `google_drive_create_folder` - Create a folder
+- `google_drive_share` - Share a file with someone
+
+**Google Docs:**
+- `google_docs_create` - Create a new document
+- `google_docs_read` - Read document content
+- `google_docs_write` - Append text to a document
+
+Users must first connect their Google account using `google_connect`.
+""".strip()
+
+# API base URLs
+SHEETS_API_URL = "https://sheets.googleapis.com/v4"
+DRIVE_API_URL = "https://www.googleapis.com/drive/v3"
+DOCS_API_URL = "https://docs.googleapis.com/v1"
+
+
+async def _google_request(
+    user_id: str,
+    method: str,
+    url: str,
+    params: dict | None = None,
+    json_data: dict | None = None,
+) -> dict | list | str:
+    """Make an authenticated Google API request.
+
+    Args:
+        user_id: User making the request
+        method: HTTP method
+        url: Full API URL
+        params: Query parameters
+        json_data: JSON body
+
+    Returns:
+        API response data
+    """
+    token = await get_valid_token(user_id)
+    if not token:
+        raise ValueError(
+            "Google account not connected. Use google_connect to connect first."
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.request(
+            method,
+            url,
+            headers=headers,
+            params=params,
+            json=json_data,
+            timeout=60.0,
+        )
+
+        if response.status_code == 204:
+            return {"success": True}
+
+        if response.status_code >= 400:
+            error_msg = response.text
+            try:
+                error_data = response.json()
+                error_msg = (
+                    error_data.get("error", {}).get("message", response.text)
+                    if isinstance(error_data.get("error"), dict)
+                    else response.text
+                )
+            except Exception:
+                pass
+            raise ValueError(f"Google API error ({response.status_code}): {error_msg}")
+
+        return response.json()
+
+
+# =============================================================================
+# Connection / Auth Tools
+# =============================================================================
+
+
+async def google_connect(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Generate OAuth URL for connecting Google account."""
+    if not is_configured():
+        return "Error: Google OAuth is not configured on this server."
+
+    if is_user_connected(ctx.user_id):
+        return "Already connected. Use google_disconnect first to reconnect."
+
+    try:
+        url = get_authorization_url(ctx.user_id)
+        return f"Click this link to connect your Google account:\n{url}"
+    except Exception as e:
+        return f"Error generating authorization URL: {e}"
+
+
+async def google_status(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Check if user's Google account is connected."""
+    if not is_configured():
+        return json.dumps({
+            "configured": False,
+            "connected": False,
+            "message": "Google OAuth not configured",
+        })
+
+    connected = is_user_connected(ctx.user_id)
+    return json.dumps(
+        {
+            "configured": True,
+            "connected": connected,
+            "message": "Connected" if connected else "Not connected",
+        }
+    )
+
+
+async def google_disconnect(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Disconnect user's Google account."""
+    if not is_user_connected(ctx.user_id):
+        return "Your Google account is not connected."
+
+    try:
+        await revoke_token(ctx.user_id)
+        return "Google account disconnected successfully."
+    except Exception as e:
+        return f"Error disconnecting: {e}"
+
+
+# =============================================================================
+# Google Sheets Tools
+# =============================================================================
+
+
+async def sheets_create(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Create a new Google Spreadsheet."""
+    title = args.get("title", "Untitled Spreadsheet")
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{SHEETS_API_URL}/spreadsheets",
+            json_data={"properties": {"title": title}},
+        )
+        return json.dumps(
+            {
+                "spreadsheet_id": data.get("spreadsheetId"),
+                "title": data.get("properties", {}).get("title"),
+                "url": data.get("spreadsheetUrl"),
+            },
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def sheets_read(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Read data from a spreadsheet range."""
+    spreadsheet_id = args.get("spreadsheet_id")
+    range_notation = args.get("range", "Sheet1")
+
+    if not spreadsheet_id:
+        return "Error: spreadsheet_id is required"
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{SHEETS_API_URL}/spreadsheets/{spreadsheet_id}/values/{range_notation}",
+        )
+        values = data.get("values", [])
+        return json.dumps({"range": data.get("range"), "values": values}, indent=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def sheets_write(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Write data to a spreadsheet range."""
+    spreadsheet_id = args.get("spreadsheet_id")
+    range_notation = args.get("range", "Sheet1!A1")
+    values = args.get("values", [])
+
+    if not spreadsheet_id:
+        return "Error: spreadsheet_id is required"
+    if not values:
+        return "Error: values array is required"
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "PUT",
+            f"{SHEETS_API_URL}/spreadsheets/{spreadsheet_id}/values/{range_notation}",
+            params={"valueInputOption": "USER_ENTERED"},
+            json_data={"values": values},
+        )
+        return json.dumps(
+            {
+                "updated_range": data.get("updatedRange"),
+                "updated_rows": data.get("updatedRows"),
+                "updated_columns": data.get("updatedColumns"),
+                "updated_cells": data.get("updatedCells"),
+            },
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def sheets_append(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Append rows to a spreadsheet."""
+    spreadsheet_id = args.get("spreadsheet_id")
+    range_notation = args.get("range", "Sheet1")
+    values = args.get("values", [])
+
+    if not spreadsheet_id:
+        return "Error: spreadsheet_id is required"
+    if not values:
+        return "Error: values array is required"
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{SHEETS_API_URL}/spreadsheets/{spreadsheet_id}/values/{range_notation}:append",
+            params={
+                "valueInputOption": "USER_ENTERED",
+                "insertDataOption": "INSERT_ROWS",
+            },
+            json_data={"values": values},
+        )
+        updates = data.get("updates", {})
+        return json.dumps(
+            {
+                "updated_range": updates.get("updatedRange"),
+                "updated_rows": updates.get("updatedRows"),
+            },
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def sheets_list(args: dict[str, Any], ctx: ToolContext) -> str:
+    """List user's spreadsheets."""
+    max_results = min(args.get("max_results", 20), 100)
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{DRIVE_API_URL}/files",
+            params={
+                "q": "mimeType='application/vnd.google-apps.spreadsheet'",
+                "pageSize": max_results,
+                "fields": "files(id,name,modifiedTime,webViewLink)",
+            },
+        )
+        files = data.get("files", [])
+        spreadsheets = [
+            {
+                "id": f.get("id"),
+                "name": f.get("name"),
+                "modified": f.get("modifiedTime"),
+                "url": f.get("webViewLink"),
+            }
+            for f in files
+        ]
+        return json.dumps(
+            {"count": len(spreadsheets), "spreadsheets": spreadsheets}, indent=2
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# =============================================================================
+# Google Drive Tools
+# =============================================================================
+
+
+async def drive_list(args: dict[str, Any], ctx: ToolContext) -> str:
+    """List files in Google Drive."""
+    query = args.get("query", "")
+    max_results = min(args.get("max_results", 20), 100)
+    folder_id = args.get("folder_id")
+
+    try:
+        q_parts = []
+        if query:
+            q_parts.append(f"name contains '{query}'")
+        if folder_id:
+            q_parts.append(f"'{folder_id}' in parents")
+        q_parts.append("trashed=false")
+
+        data = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{DRIVE_API_URL}/files",
+            params={
+                "q": " and ".join(q_parts) if q_parts else None,
+                "pageSize": max_results,
+                "fields": "files(id,name,mimeType,size,modifiedTime,webViewLink)",
+            },
+        )
+        files = data.get("files", [])
+        result = [
+            {
+                "id": f.get("id"),
+                "name": f.get("name"),
+                "type": f.get("mimeType"),
+                "size": f.get("size"),
+                "modified": f.get("modifiedTime"),
+                "url": f.get("webViewLink"),
+            }
+            for f in files
+        ]
+        return json.dumps({"count": len(result), "files": result}, indent=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def drive_upload(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Upload text content as a file to Google Drive."""
+    name = args.get("name", "untitled.txt")
+    content = args.get("content", "")
+    folder_id = args.get("folder_id")
+    mime_type = args.get("mime_type", "text/plain")
+
+    if not content:
+        return "Error: content is required"
+
+    try:
+        # Create file metadata
+        metadata: dict[str, Any] = {"name": name}
+        if folder_id:
+            metadata["parents"] = [folder_id]
+
+        # Use multipart upload for simplicity with text content
+        token = await get_valid_token(ctx.user_id)
+        if not token:
+            return "Error: Google account not connected"
+
+        # Simple upload for small files
+        async with httpx.AsyncClient() as client:
+            # First create metadata
+            response = await client.post(
+                f"{DRIVE_API_URL}/files",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                params={"uploadType": "multipart"},
+                json=metadata,
+                timeout=60.0,
+            )
+
+            if response.status_code >= 400:
+                return f"Error creating file: {response.text}"
+
+            file_data = response.json()
+            file_id = file_data.get("id")
+
+            # Then upload content
+            response = await client.patch(
+                f"https://www.googleapis.com/upload/drive/v3/files/{file_id}",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": mime_type,
+                },
+                params={"uploadType": "media"},
+                content=content.encode(),
+                timeout=60.0,
+            )
+
+            if response.status_code >= 400:
+                return f"Error uploading content: {response.text}"
+
+            return json.dumps(
+                {"file_id": file_id, "name": name, "uploaded": True}, indent=2
+            )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def drive_download(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Download file content from Google Drive."""
+    file_id = args.get("file_id")
+
+    if not file_id:
+        return "Error: file_id is required"
+
+    try:
+        token = await get_valid_token(ctx.user_id)
+        if not token:
+            return "Error: Google account not connected"
+
+        # Get file metadata first
+        metadata = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{DRIVE_API_URL}/files/{file_id}",
+            params={"fields": "name,mimeType,size"},
+        )
+
+        mime_type = metadata.get("mimeType", "")
+
+        # For Google Docs types, export as text
+        async with httpx.AsyncClient() as client:
+            if "google-apps" in mime_type:
+                # Export Google Docs format
+                export_mime = "text/plain"
+                if "spreadsheet" in mime_type:
+                    export_mime = "text/csv"
+                elif "document" in mime_type:
+                    export_mime = "text/plain"
+
+                response = await client.get(
+                    f"{DRIVE_API_URL}/files/{file_id}/export",
+                    headers={"Authorization": f"Bearer {token}"},
+                    params={"mimeType": export_mime},
+                    timeout=60.0,
+                )
+            else:
+                # Download regular file
+                response = await client.get(
+                    f"{DRIVE_API_URL}/files/{file_id}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    params={"alt": "media"},
+                    timeout=60.0,
+                )
+
+            if response.status_code >= 400:
+                return f"Error downloading: {response.text}"
+
+            content = response.text
+            # Truncate if too long
+            if len(content) > 50000:
+                content = content[:50000] + "\n... (truncated)"
+
+            return json.dumps(
+                {
+                    "name": metadata.get("name"),
+                    "mime_type": mime_type,
+                    "content": content,
+                },
+                indent=2,
+            )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def drive_create_folder(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Create a folder in Google Drive."""
+    name = args.get("name", "New Folder")
+    parent_id = args.get("parent_id")
+
+    try:
+        metadata: dict[str, Any] = {
+            "name": name,
+            "mimeType": "application/vnd.google-apps.folder",
+        }
+        if parent_id:
+            metadata["parents"] = [parent_id]
+
+        data = await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{DRIVE_API_URL}/files",
+            json_data=metadata,
+        )
+        return json.dumps(
+            {"folder_id": data.get("id"), "name": data.get("name")}, indent=2
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def drive_share(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Share a file or folder with someone."""
+    file_id = args.get("file_id")
+    email = args.get("email")
+    role = args.get("role", "reader")  # reader, writer, commenter
+
+    if not file_id:
+        return "Error: file_id is required"
+    if not email:
+        return "Error: email is required"
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{DRIVE_API_URL}/files/{file_id}/permissions",
+            json_data={"type": "user", "role": role, "emailAddress": email},
+        )
+        return json.dumps(
+            {"shared": True, "permission_id": data.get("id"), "role": role}, indent=2
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# =============================================================================
+# Google Docs Tools
+# =============================================================================
+
+
+async def docs_create(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Create a new Google Doc."""
+    title = args.get("title", "Untitled Document")
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{DOCS_API_URL}/documents",
+            json_data={"title": title},
+        )
+        doc_id = data.get("documentId")
+        return json.dumps(
+            {
+                "document_id": doc_id,
+                "title": data.get("title"),
+                "url": f"https://docs.google.com/document/d/{doc_id}/edit",
+            },
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def docs_read(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Read content from a Google Doc."""
+    document_id = args.get("document_id")
+
+    if not document_id:
+        return "Error: document_id is required"
+
+    try:
+        data = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{DOCS_API_URL}/documents/{document_id}",
+        )
+
+        # Extract text content from document body
+        content_parts = []
+        body = data.get("body", {})
+        for element in body.get("content", []):
+            if "paragraph" in element:
+                for elem in element["paragraph"].get("elements", []):
+                    if "textRun" in elem:
+                        content_parts.append(elem["textRun"].get("content", ""))
+
+        content = "".join(content_parts)
+
+        return json.dumps(
+            {
+                "document_id": document_id,
+                "title": data.get("title"),
+                "content": content,
+            },
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+async def docs_write(args: dict[str, Any], ctx: ToolContext) -> str:
+    """Append text to a Google Doc."""
+    document_id = args.get("document_id")
+    text = args.get("text", "")
+
+    if not document_id:
+        return "Error: document_id is required"
+    if not text:
+        return "Error: text is required"
+
+    try:
+        # Get current document to find end index
+        doc = await _google_request(
+            ctx.user_id,
+            "GET",
+            f"{DOCS_API_URL}/documents/{document_id}",
+        )
+
+        # Find end of body content
+        body = doc.get("body", {})
+        end_index = body.get("content", [{}])[-1].get("endIndex", 1)
+
+        # Insert text at end (before the newline at endIndex)
+        insert_index = max(1, end_index - 1)
+
+        await _google_request(
+            ctx.user_id,
+            "POST",
+            f"{DOCS_API_URL}/documents/{document_id}:batchUpdate",
+            json_data={
+                "requests": [
+                    {
+                        "insertText": {
+                            "location": {"index": insert_index},
+                            "text": text,
+                        }
+                    }
+                ]
+            },
+        )
+
+        return json.dumps({"document_id": document_id, "text_appended": True}, indent=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# =============================================================================
+# Tool Definitions
+# =============================================================================
+
+
+def _is_available() -> bool:
+    """Check if Google Workspace tools are available."""
+    return is_configured()
+
+
+TOOLS = [
+    # Connection tools
+    ToolDef(
+        name="google_connect",
+        description="Generate OAuth URL to connect your Google account.",
+        parameters={"type": "object", "properties": {}, "required": []},
+        handler=google_connect,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_status",
+        description="Check if your Google account is connected.",
+        parameters={"type": "object", "properties": {}, "required": []},
+        handler=google_status,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_disconnect",
+        description="Disconnect your Google account and revoke access.",
+        parameters={"type": "object", "properties": {}, "required": []},
+        handler=google_disconnect,
+        requires=["google_oauth"],
+    ),
+    # Sheets tools
+    ToolDef(
+        name="google_sheets_create",
+        description="Create a new Google Spreadsheet.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Title for the new spreadsheet",
+                }
+            },
+            "required": [],
+        },
+        handler=sheets_create,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_sheets_read",
+        description="Read data from a spreadsheet range (A1 notation).",
+        parameters={
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {
+                    "type": "string",
+                    "description": "Spreadsheet ID from the URL",
+                },
+                "range": {
+                    "type": "string",
+                    "description": "Range in A1 notation (e.g., 'Sheet1!A1:D10')",
+                },
+            },
+            "required": ["spreadsheet_id"],
+        },
+        handler=sheets_read,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_sheets_write",
+        description="Write data to a spreadsheet range. Values should be a 2D array.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {
+                    "type": "string",
+                    "description": "Spreadsheet ID from the URL",
+                },
+                "range": {
+                    "type": "string",
+                    "description": "Range in A1 notation (e.g., 'Sheet1!A1')",
+                },
+                "values": {
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": "2D array of values to write",
+                },
+            },
+            "required": ["spreadsheet_id", "values"],
+        },
+        handler=sheets_write,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_sheets_append",
+        description="Append rows to a spreadsheet. Values should be a 2D array.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {
+                    "type": "string",
+                    "description": "Spreadsheet ID from the URL",
+                },
+                "range": {
+                    "type": "string",
+                    "description": "Sheet name or range (e.g., 'Sheet1')",
+                },
+                "values": {
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": "2D array of rows to append",
+                },
+            },
+            "required": ["spreadsheet_id", "values"],
+        },
+        handler=sheets_append,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_sheets_list",
+        description="List your Google Spreadsheets.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default 20)",
+                }
+            },
+            "required": [],
+        },
+        handler=sheets_list,
+        requires=["google_oauth"],
+    ),
+    # Drive tools
+    ToolDef(
+        name="google_drive_list",
+        description="List files in your Google Drive.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query for file names",
+                },
+                "folder_id": {
+                    "type": "string",
+                    "description": "Folder ID to list contents of",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default 20)",
+                },
+            },
+            "required": [],
+        },
+        handler=drive_list,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_drive_upload",
+        description="Upload text content as a file to Google Drive.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "File name (e.g., 'notes.txt')",
+                },
+                "content": {"type": "string", "description": "Text content to upload"},
+                "folder_id": {
+                    "type": "string",
+                    "description": "Folder ID to upload to (optional)",
+                },
+                "mime_type": {
+                    "type": "string",
+                    "description": "MIME type (default: text/plain)",
+                },
+            },
+            "required": ["name", "content"],
+        },
+        handler=drive_upload,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_drive_download",
+        description="Download file content from Google Drive.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "file_id": {"type": "string", "description": "File ID to download"}
+            },
+            "required": ["file_id"],
+        },
+        handler=drive_download,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_drive_create_folder",
+        description="Create a folder in Google Drive.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Folder name"},
+                "parent_id": {
+                    "type": "string",
+                    "description": "Parent folder ID (optional)",
+                },
+            },
+            "required": ["name"],
+        },
+        handler=drive_create_folder,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_drive_share",
+        description="Share a file or folder with someone.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "file_id": {"type": "string", "description": "File or folder ID"},
+                "email": {"type": "string", "description": "Email to share with"},
+                "role": {
+                    "type": "string",
+                    "enum": ["reader", "writer", "commenter"],
+                    "description": "Permission role (default: reader)",
+                },
+            },
+            "required": ["file_id", "email"],
+        },
+        handler=drive_share,
+        requires=["google_oauth"],
+    ),
+    # Docs tools
+    ToolDef(
+        name="google_docs_create",
+        description="Create a new Google Doc.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Title for the new document",
+                }
+            },
+            "required": [],
+        },
+        handler=docs_create,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_docs_read",
+        description="Read content from a Google Doc.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "string",
+                    "description": "Document ID from the URL",
+                }
+            },
+            "required": ["document_id"],
+        },
+        handler=docs_read,
+        requires=["google_oauth"],
+    ),
+    ToolDef(
+        name="google_docs_write",
+        description="Append text to a Google Doc.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "string",
+                    "description": "Document ID from the URL",
+                },
+                "text": {"type": "string", "description": "Text to append"},
+            },
+            "required": ["document_id", "text"],
+        },
+        handler=docs_write,
+        requires=["google_oauth"],
+    ),
+]


### PR DESCRIPTION
## Summary
- Adds per-user OAuth 2.0 authentication for Google Workspace APIs
- Implements 16 new tools for Sheets, Drive, and Docs integration
- OAuth callback runs on discord monitor server (Railway compatible)

## Changes
- `db/models.py`: Add `GoogleOAuthToken` model for per-user token storage
- `tools/google_oauth.py`: OAuth helper (auth URL, token exchange, refresh, revoke)
- `tools/google_workspace.py`: 16 tools (3 auth + 5 sheets + 5 drive + 3 docs)
- `discord_bot.py`: OAuth callback endpoints (`/oauth/google/callback`, `/oauth/google/status/{user_id}`)
- `CLAUDE.md`: Documentation for new integration

## New Tools
| Category | Tools |
|----------|-------|
| Auth | `google_connect`, `google_status`, `google_disconnect` |
| Sheets | `google_sheets_create`, `google_sheets_read`, `google_sheets_write`, `google_sheets_append`, `google_sheets_list` |
| Drive | `google_drive_list`, `google_drive_upload`, `google_drive_download`, `google_drive_create_folder`, `google_drive_share` |
| Docs | `google_docs_create`, `google_docs_read`, `google_docs_write` |

## Environment Variables Required
```
GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com
GOOGLE_CLIENT_SECRET=xxx
GOOGLE_REDIRECT_URI=https://your-railway-app.up.railway.app/oauth/google/callback
```

## Test plan
- [ ] Set up Google Cloud OAuth credentials
- [ ] Enable Sheets, Drive, and Docs APIs in Google Cloud Console
- [ ] Configure redirect URI in Google Cloud Console
- [ ] Test `google_connect` generates valid OAuth URL
- [ ] Test OAuth callback stores tokens correctly
- [ ] Test Sheets read/write operations
- [ ] Test Drive list/upload/download operations
- [ ] Test Docs create/read/write operations

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)