### PR TITLE
fix: add vendor/ directory to Dockerfile.discord

### DIFF
--- a/Dockerfile.discord
+++ b/Dockerfile.discord
@@ -33,6 +33,7 @@ COPY db/ ./db/
 COPY sandbox/ ./sandbox/
 COPY storage/ ./storage/
 COPY tools/ ./tools/
+COPY vendor/ ./vendor/
 COPY personalities/ ./personalities/
 COPY VERSION ./
 


### PR DESCRIPTION
## Summary
- Adds missing `vendor/` directory to Docker build
- Fixes `ModuleNotFoundError: No module named 'vendor'` on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)