### PR TITLE
fix: update vendor mem0 imports to use vendor.mem0 prefix

### DIFF
--- a/vendor/mem0/__init__.py
+++ b/vendor/mem0/__init__.py
@@ -1,6 +1,5 @@
-import importlib.metadata
+# Vendored mem0 with local fixes - version hardcoded since we're not using pip
+__version__ = "1.0.1"
 
-__version__ = importlib.metadata.version("mem0ai")
-
-from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
-from mem0.memory.main import AsyncMemory, Memory  # noqa
+from vendor.mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
+from vendor.mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/vendor/mem0/client/main.py
+++ b/vendor/mem0/client/main.py
@@ -7,11 +7,11 @@ from typing import Any, Dict, List, Optional
 import httpx
 import requests
 
-from mem0.client.project import AsyncProject, Project
-from mem0.client.utils import api_error_handler
+from vendor.mem0.client.project import AsyncProject, Project
+from vendor.mem0.client.utils import api_error_handler
 # Exception classes are referenced in docstrings only
-from mem0.memory.setup import get_user_id, setup_config
-from mem0.memory.telemetry import capture_client_event
+from vendor.mem0.memory.setup import get_user_id, setup_config
+from vendor.mem0.memory.telemetry import capture_client_event
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/client/project.py
+++ b/vendor/mem0/client/project.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
-from mem0.client.utils import api_error_handler
-from mem0.memory.telemetry import capture_client_event
+from vendor.mem0.client.utils import api_error_handler
+from vendor.mem0.memory.telemetry import capture_client_event
 # Exception classes are referenced in docstrings only
 
 logger = logging.getLogger(__name__)

--- a/vendor/mem0/client/utils.py
+++ b/vendor/mem0/client/utils.py
@@ -2,7 +2,7 @@ import json
 import logging
 import httpx
 
-from mem0.exceptions import (
+from vendor.mem0.exceptions import (
     NetworkError,
     create_exception_from_response,
 )
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class APIError(Exception):
     """Exception raised for errors in the API.
     
-    Deprecated: Use specific exception classes from mem0.exceptions instead.
+    Deprecated: Use specific exception classes from vendor.mem0.exceptions instead.
     This class is maintained for backward compatibility.
     """
 

--- a/vendor/mem0/configs/base.py
+++ b/vendor/mem0/configs/base.py
@@ -3,11 +3,11 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from mem0.embeddings.configs import EmbedderConfig
-from mem0.graphs.configs import GraphStoreConfig
-from mem0.llms.configs import LlmConfig
-from mem0.vector_stores.configs import VectorStoreConfig
-from mem0.configs.rerankers.config import RerankerConfig
+from vendor.mem0.embeddings.configs import EmbedderConfig
+from vendor.mem0.graphs.configs import GraphStoreConfig
+from vendor.mem0.llms.configs import LlmConfig
+from vendor.mem0.vector_stores.configs import VectorStoreConfig
+from vendor.mem0.configs.rerankers.config import RerankerConfig
 
 # Set up the directory path
 home_dir = os.path.expanduser("~")

--- a/vendor/mem0/configs/embeddings/base.py
+++ b/vendor/mem0/configs/embeddings/base.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 
 import httpx
 
-from mem0.configs.base import AzureConfig
+from vendor.mem0.configs.base import AzureConfig
 
 
 class BaseEmbedderConfig(ABC):

--- a/vendor/mem0/configs/llms/anthropic.py
+++ b/vendor/mem0/configs/llms/anthropic.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class AnthropicConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/aws_bedrock.py
+++ b/vendor/mem0/configs/llms/aws_bedrock.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict, List, Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class AWSBedrockConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/azure.py
+++ b/vendor/mem0/configs/llms/azure.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
-from mem0.configs.base import AzureConfig
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.base import AzureConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class AzureOpenAIConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/deepseek.py
+++ b/vendor/mem0/configs/llms/deepseek.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class DeepSeekConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/lmstudio.py
+++ b/vendor/mem0/configs/llms/lmstudio.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class LMStudioConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/ollama.py
+++ b/vendor/mem0/configs/llms/ollama.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class OllamaConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/openai.py
+++ b/vendor/mem0/configs/llms/openai.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, List, Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class OpenAIConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/llms/vllm.py
+++ b/vendor/mem0/configs/llms/vllm.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class VllmConfig(BaseLlmConfig):

--- a/vendor/mem0/configs/rerankers/cohere.py
+++ b/vendor/mem0/configs/rerankers/cohere.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from pydantic import Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
 
 
 class CohereRerankerConfig(BaseRerankerConfig):

--- a/vendor/mem0/configs/rerankers/huggingface.py
+++ b/vendor/mem0/configs/rerankers/huggingface.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from pydantic import Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
 
 
 class HuggingFaceRerankerConfig(BaseRerankerConfig):

--- a/vendor/mem0/configs/rerankers/llm.py
+++ b/vendor/mem0/configs/rerankers/llm.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from pydantic import Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
 
 
 class LLMRerankerConfig(BaseRerankerConfig):

--- a/vendor/mem0/configs/rerankers/sentence_transformer.py
+++ b/vendor/mem0/configs/rerankers/sentence_transformer.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from pydantic import Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
 
 
 class SentenceTransformerRerankerConfig(BaseRerankerConfig):

--- a/vendor/mem0/configs/rerankers/zero_entropy.py
+++ b/vendor/mem0/configs/rerankers/zero_entropy.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from pydantic import Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
 
 
 class ZeroEntropyRerankerConfig(BaseRerankerConfig):

--- a/vendor/mem0/embeddings/aws_bedrock.py
+++ b/vendor/mem0/embeddings/aws_bedrock.py
@@ -9,8 +9,8 @@ except ImportError:
 
 import numpy as np
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class AWSBedrockEmbedding(EmbeddingBase):

--- a/vendor/mem0/embeddings/azure_openai.py
+++ b/vendor/mem0/embeddings/azure_openai.py
@@ -4,8 +4,8 @@ from typing import Literal, Optional
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 SCOPE = "https://cognitiveservices.azure.com/.default"
 

--- a/vendor/mem0/embeddings/base.py
+++ b/vendor/mem0/embeddings/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Literal, Optional
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
 
 
 class EmbeddingBase(ABC):

--- a/vendor/mem0/embeddings/fastembed.py
+++ b/vendor/mem0/embeddings/fastembed.py
@@ -1,7 +1,7 @@
 from typing import Optional, Literal
 
-from mem0.embeddings.base import EmbeddingBase
-from mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
 
 try:
     from fastembed import TextEmbedding

--- a/vendor/mem0/embeddings/gemini.py
+++ b/vendor/mem0/embeddings/gemini.py
@@ -4,8 +4,8 @@ from typing import Literal, Optional
 from google import genai
 from google.genai import types
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class GoogleGenAIEmbedding(EmbeddingBase):

--- a/vendor/mem0/embeddings/huggingface.py
+++ b/vendor/mem0/embeddings/huggingface.py
@@ -4,8 +4,8 @@ from typing import Literal, Optional
 from openai import OpenAI
 from sentence_transformers import SentenceTransformer
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 logging.getLogger("transformers").setLevel(logging.WARNING)
 logging.getLogger("sentence_transformers").setLevel(logging.WARNING)

--- a/vendor/mem0/embeddings/langchain.py
+++ b/vendor/mem0/embeddings/langchain.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 try:
     from langchain.embeddings.base import Embeddings

--- a/vendor/mem0/embeddings/lmstudio.py
+++ b/vendor/mem0/embeddings/lmstudio.py
@@ -2,8 +2,8 @@ from typing import Literal, Optional
 
 from openai import OpenAI
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class LMStudioEmbedding(EmbeddingBase):

--- a/vendor/mem0/embeddings/mock.py
+++ b/vendor/mem0/embeddings/mock.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class MockEmbeddings(EmbeddingBase):

--- a/vendor/mem0/embeddings/ollama.py
+++ b/vendor/mem0/embeddings/ollama.py
@@ -2,8 +2,8 @@ import subprocess
 import sys
 from typing import Literal, Optional
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 try:
     from ollama import Client

--- a/vendor/mem0/embeddings/openai.py
+++ b/vendor/mem0/embeddings/openai.py
@@ -4,8 +4,8 @@ from typing import Literal, Optional
 
 from openai import OpenAI
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class OpenAIEmbedding(EmbeddingBase):

--- a/vendor/mem0/embeddings/together.py
+++ b/vendor/mem0/embeddings/together.py
@@ -3,8 +3,8 @@ from typing import Literal, Optional
 
 from together import Together
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
 
 
 class TogetherEmbedding(EmbeddingBase):

--- a/vendor/mem0/embeddings/vertexai.py
+++ b/vendor/mem0/embeddings/vertexai.py
@@ -3,9 +3,9 @@ from typing import Literal, Optional
 
 from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.embeddings.base import EmbeddingBase
-from mem0.utils.gcp_auth import GCPAuthenticator
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.embeddings.base import EmbeddingBase
+from vendor.mem0.utils.gcp_auth import GCPAuthenticator
 
 
 class VertexAIEmbedding(EmbeddingBase):

--- a/vendor/mem0/graphs/configs.py
+++ b/vendor/mem0/graphs/configs.py
@@ -2,7 +2,7 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from mem0.llms.configs import LlmConfig
+from vendor.mem0.llms.configs import LlmConfig
 
 
 class Neo4jConfig(BaseModel):

--- a/vendor/mem0/graphs/neptune/base.py
+++ b/vendor/mem0/graphs/neptune/base.py
@@ -1,14 +1,14 @@
 import logging
 from abc import ABC, abstractmethod
 
-from mem0.memory.utils import format_entities
+from vendor.mem0.memory.utils import format_entities
 
 try:
     from rank_bm25 import BM25Okapi
 except ImportError:
     raise ImportError("rank_bm25 is not installed. Please install it using pip install rank-bm25")
 
-from mem0.graphs.tools import (
+from vendor.mem0.graphs.tools import (
     DELETE_MEMORY_STRUCT_TOOL_GRAPH,
     DELETE_MEMORY_TOOL_GRAPH,
     EXTRACT_ENTITIES_STRUCT_TOOL,
@@ -16,8 +16,8 @@ from mem0.graphs.tools import (
     RELATIONS_STRUCT_TOOL,
     RELATIONS_TOOL,
 )
-from mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
-from mem0.utils.factory import EmbedderFactory, LlmFactory, VectorStoreFactory
+from vendor.mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
+from vendor.mem0.utils.factory import EmbedderFactory, LlmFactory, VectorStoreFactory
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/llms/anthropic.py
+++ b/vendor/mem0/llms/anthropic.py
@@ -6,9 +6,9 @@ try:
 except ImportError:
     raise ImportError("The 'anthropic' library is required. Please install it using 'pip install anthropic'.")
 
-from mem0.configs.llms.anthropic import AnthropicConfig
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.anthropic import AnthropicConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class AnthropicLLM(LLMBase):

--- a/vendor/mem0/llms/aws_bedrock.py
+++ b/vendor/mem0/llms/aws_bedrock.py
@@ -9,10 +9,10 @@ try:
 except ImportError:
     raise ImportError("The 'boto3' library is required. Please install it using 'pip install boto3'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.aws_bedrock import AWSBedrockConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/llms/azure_openai.py
+++ b/vendor/mem0/llms/azure_openai.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Optional, Union
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
-from mem0.configs.llms.azure import AzureOpenAIConfig
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.azure import AzureOpenAIConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 SCOPE = "https://cognitiveservices.azure.com/.default"
 

--- a/vendor/mem0/llms/azure_openai_structured.py
+++ b/vendor/mem0/llms/azure_openai_structured.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Optional
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 SCOPE = "https://cognitiveservices.azure.com/.default"
 

--- a/vendor/mem0/llms/base.py
+++ b/vendor/mem0/llms/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 
-from mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
 
 
 class LLMBase(ABC):

--- a/vendor/mem0/llms/deepseek.py
+++ b/vendor/mem0/llms/deepseek.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.deepseek import DeepSeekConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.deepseek import DeepSeekConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class DeepSeekLLM(LLMBase):

--- a/vendor/mem0/llms/gemini.py
+++ b/vendor/mem0/llms/gemini.py
@@ -7,8 +7,8 @@ try:
 except ImportError:
     raise ImportError("The 'google-genai' library is required. Please install it using 'pip install google-genai'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class GeminiLLM(LLMBase):

--- a/vendor/mem0/llms/groq.py
+++ b/vendor/mem0/llms/groq.py
@@ -7,9 +7,9 @@ try:
 except ImportError:
     raise ImportError("The 'groq' library is required. Please install it using 'pip install groq'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class GroqLLM(LLMBase):

--- a/vendor/mem0/llms/langchain.py
+++ b/vendor/mem0/llms/langchain.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 try:
     from langchain.chat_models.base import BaseChatModel

--- a/vendor/mem0/llms/litellm.py
+++ b/vendor/mem0/llms/litellm.py
@@ -6,9 +6,9 @@ try:
 except ImportError:
     raise ImportError("The 'litellm' library is required. Please install it using 'pip install litellm'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class LiteLLM(LLMBase):

--- a/vendor/mem0/llms/lmstudio.py
+++ b/vendor/mem0/llms/lmstudio.py
@@ -3,10 +3,10 @@ from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.lmstudio import LMStudioConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.lmstudio import LMStudioConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class LMStudioLLM(LLMBase):

--- a/vendor/mem0/llms/ollama.py
+++ b/vendor/mem0/llms/ollama.py
@@ -5,9 +5,9 @@ try:
 except ImportError:
     raise ImportError("The 'ollama' library is required. Please install it using 'pip install ollama'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.ollama import OllamaConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.ollama import OllamaConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class OllamaLLM(LLMBase):

--- a/vendor/mem0/llms/openai.py
+++ b/vendor/mem0/llms/openai.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.openai import OpenAIConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.openai import OpenAIConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class OpenAILLM(LLMBase):

--- a/vendor/mem0/llms/openai_structured.py
+++ b/vendor/mem0/llms/openai_structured.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class OpenAIStructuredLLM(LLMBase):

--- a/vendor/mem0/llms/sarvam.py
+++ b/vendor/mem0/llms/sarvam.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional
 
 import requests
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class SarvamLLM(LLMBase):

--- a/vendor/mem0/llms/together.py
+++ b/vendor/mem0/llms/together.py
@@ -7,9 +7,9 @@ try:
 except ImportError:
     raise ImportError("The 'together' library is required. Please install it using 'pip install together'.")
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class TogetherLLM(LLMBase):

--- a/vendor/mem0/llms/vllm.py
+++ b/vendor/mem0/llms/vllm.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.vllm import VllmConfig
-from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.vllm import VllmConfig
+from vendor.mem0.llms.base import LLMBase
+from vendor.mem0.memory.utils import extract_json
 
 
 class VllmLLM(LLMBase):

--- a/vendor/mem0/llms/xai.py
+++ b/vendor/mem0/llms/xai.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional
 
 from openai import OpenAI
 
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.llms.base import LLMBase
 
 
 class XAILLM(LLMBase):

--- a/vendor/mem0/memory/graph_memory.py
+++ b/vendor/mem0/memory/graph_memory.py
@@ -1,6 +1,6 @@
 import logging
 
-from mem0.memory.utils import format_entities, sanitize_relationship_for_cypher
+from vendor.mem0.memory.utils import format_entities, sanitize_relationship_for_cypher
 
 try:
     from langchain_neo4j import Neo4jGraph
@@ -12,7 +12,7 @@ try:
 except ImportError:
     raise ImportError("rank_bm25 is not installed. Please install it using pip install rank-bm25")
 
-from mem0.graphs.tools import (
+from vendor.mem0.graphs.tools import (
     DELETE_MEMORY_STRUCT_TOOL_GRAPH,
     DELETE_MEMORY_TOOL_GRAPH,
     EXTRACT_ENTITIES_STRUCT_TOOL,
@@ -20,8 +20,8 @@ from mem0.graphs.tools import (
     RELATIONS_STRUCT_TOOL,
     RELATIONS_TOOL,
 )
-from mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
-from mem0.utils.factory import EmbedderFactory, LlmFactory
+from vendor.mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
+from vendor.mem0.utils.factory import EmbedderFactory, LlmFactory
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/memory/kuzu_memory.py
+++ b/vendor/mem0/memory/kuzu_memory.py
@@ -1,6 +1,6 @@
 import logging
 
-from mem0.memory.utils import format_entities
+from vendor.mem0.memory.utils import format_entities
 
 try:
     import kuzu
@@ -12,7 +12,7 @@ try:
 except ImportError:
     raise ImportError("rank_bm25 is not installed. Please install it using pip install rank-bm25")
 
-from mem0.graphs.tools import (
+from vendor.mem0.graphs.tools import (
     DELETE_MEMORY_STRUCT_TOOL_GRAPH,
     DELETE_MEMORY_TOOL_GRAPH,
     EXTRACT_ENTITIES_STRUCT_TOOL,
@@ -20,8 +20,8 @@ from mem0.graphs.tools import (
     RELATIONS_STRUCT_TOOL,
     RELATIONS_TOOL,
 )
-from mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
-from mem0.utils.factory import EmbedderFactory, LlmFactory
+from vendor.mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
+from vendor.mem0.utils.factory import EmbedderFactory, LlmFactory
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/memory/main.py
+++ b/vendor/mem0/memory/main.py
@@ -14,18 +14,18 @@ from typing import Any, Dict, Optional
 import pytz
 from pydantic import ValidationError
 
-from mem0.configs.base import MemoryConfig, MemoryItem
-from mem0.configs.enums import MemoryType
-from mem0.configs.prompts import (
+from vendor.mem0.configs.base import MemoryConfig, MemoryItem
+from vendor.mem0.configs.enums import MemoryType
+from vendor.mem0.configs.prompts import (
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     get_update_memory_messages,
 )
-from mem0.exceptions import ValidationError as Mem0ValidationError
-from mem0.memory.base import MemoryBase
-from mem0.memory.setup import mem0_dir, setup_config
-from mem0.memory.storage import SQLiteManager
-from mem0.memory.telemetry import capture_event
-from mem0.memory.utils import (
+from vendor.mem0.exceptions import ValidationError as Mem0ValidationError
+from vendor.mem0.memory.base import MemoryBase
+from vendor.mem0.memory.setup import mem0_dir, setup_config
+from vendor.mem0.memory.storage import SQLiteManager
+from vendor.mem0.memory.telemetry import capture_event
+from vendor.mem0.memory.utils import (
     extract_json,
     get_fact_retrieval_messages,
     parse_messages,
@@ -33,7 +33,7 @@ from mem0.memory.utils import (
     process_telemetry_filters,
     remove_code_blocks,
 )
-from mem0.utils.factory import (
+from vendor.mem0.utils.factory import (
     EmbedderFactory,
     GraphStoreFactory,
     LlmFactory,

--- a/vendor/mem0/memory/memgraph_memory.py
+++ b/vendor/mem0/memory/memgraph_memory.py
@@ -1,6 +1,6 @@
 import logging
 
-from mem0.memory.utils import format_entities, sanitize_relationship_for_cypher
+from vendor.mem0.memory.utils import format_entities, sanitize_relationship_for_cypher
 
 try:
     from langchain_memgraph.graphs.memgraph import Memgraph
@@ -12,7 +12,7 @@ try:
 except ImportError:
     raise ImportError("rank_bm25 is not installed. Please install it using pip install rank-bm25")
 
-from mem0.graphs.tools import (
+from vendor.mem0.graphs.tools import (
     DELETE_MEMORY_STRUCT_TOOL_GRAPH,
     DELETE_MEMORY_TOOL_GRAPH,
     EXTRACT_ENTITIES_STRUCT_TOOL,
@@ -20,8 +20,8 @@ from mem0.graphs.tools import (
     RELATIONS_STRUCT_TOOL,
     RELATIONS_TOOL,
 )
-from mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
-from mem0.utils.factory import EmbedderFactory, LlmFactory
+from vendor.mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
+from vendor.mem0.utils.factory import EmbedderFactory, LlmFactory
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/memory/telemetry.py
+++ b/vendor/mem0/memory/telemetry.py
@@ -5,8 +5,8 @@ import sys
 
 from posthog import Posthog
 
-import mem0
-from mem0.memory.setup import get_or_create_user_id
+import vendor.mem0 as mem0
+from vendor.mem0.memory.setup import get_or_create_user_id
 
 MEM0_TELEMETRY = os.environ.get("MEM0_TELEMETRY", "True")
 PROJECT_API_KEY = "phc_hgJkUVJFYtmaJqrvf6CYN67TIQ8yhXAkWzUn9AMU4yX"

--- a/vendor/mem0/memory/utils.py
+++ b/vendor/mem0/memory/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import re
 
-from mem0.configs.prompts import (
+from vendor.mem0.configs.prompts import (
     FACT_RETRIEVAL_PROMPT,
     USER_MEMORY_EXTRACTION_PROMPT,
     AGENT_MEMORY_EXTRACTION_PROMPT,

--- a/vendor/mem0/proxy/main.py
+++ b/vendor/mem0/proxy/main.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union
 
 import httpx
 
-import mem0
+import vendor.mem0 as mem0
 
 try:
     import litellm
@@ -19,8 +19,8 @@ except ImportError:
         sys.exit(1)
 
 from mem0 import Memory, MemoryClient
-from mem0.configs.prompts import MEMORY_ANSWER_PROMPT
-from mem0.memory.telemetry import capture_client_event, capture_event
+from vendor.mem0.configs.prompts import MEMORY_ANSWER_PROMPT
+from vendor.mem0.memory.telemetry import capture_client_event, capture_event
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/reranker/cohere_reranker.py
+++ b/vendor/mem0/reranker/cohere_reranker.py
@@ -1,7 +1,7 @@
 import os
 from typing import List, Dict, Any
 
-from mem0.reranker.base import BaseReranker
+from vendor.mem0.reranker.base import BaseReranker
 
 try:
     import cohere

--- a/vendor/mem0/reranker/huggingface_reranker.py
+++ b/vendor/mem0/reranker/huggingface_reranker.py
@@ -1,9 +1,9 @@
 from typing import List, Dict, Any, Union
 import numpy as np
 
-from mem0.reranker.base import BaseReranker
-from mem0.configs.rerankers.base import BaseRerankerConfig
-from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
+from vendor.mem0.reranker.base import BaseReranker
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
 
 try:
     from transformers import AutoTokenizer, AutoModelForSequenceClassification

--- a/vendor/mem0/reranker/llm_reranker.py
+++ b/vendor/mem0/reranker/llm_reranker.py
@@ -1,10 +1,10 @@
 import re
 from typing import List, Dict, Any, Union
 
-from mem0.reranker.base import BaseReranker
-from mem0.utils.factory import LlmFactory
-from mem0.configs.rerankers.base import BaseRerankerConfig
-from mem0.configs.rerankers.llm import LLMRerankerConfig
+from vendor.mem0.reranker.base import BaseReranker
+from vendor.mem0.utils.factory import LlmFactory
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.llm import LLMRerankerConfig
 
 
 class LLMReranker(BaseReranker):

--- a/vendor/mem0/reranker/sentence_transformer_reranker.py
+++ b/vendor/mem0/reranker/sentence_transformer_reranker.py
@@ -1,9 +1,9 @@
 from typing import List, Dict, Any, Union
 import numpy as np
 
-from mem0.reranker.base import BaseReranker
-from mem0.configs.rerankers.base import BaseRerankerConfig
-from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
+from vendor.mem0.reranker.base import BaseReranker
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
 
 try:
     from sentence_transformers import SentenceTransformer

--- a/vendor/mem0/reranker/zero_entropy_reranker.py
+++ b/vendor/mem0/reranker/zero_entropy_reranker.py
@@ -1,7 +1,7 @@
 import os
 from typing import List, Dict, Any
 
-from mem0.reranker.base import BaseReranker
+from vendor.mem0.reranker.base import BaseReranker
 
 try:
     from zeroentropy import ZeroEntropy

--- a/vendor/mem0/utils/factory.py
+++ b/vendor/mem0/utils/factory.py
@@ -1,22 +1,22 @@
 import importlib
 from typing import Dict, Optional, Union
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
-from mem0.configs.llms.anthropic import AnthropicConfig
-from mem0.configs.llms.azure import AzureOpenAIConfig
-from mem0.configs.llms.base import BaseLlmConfig
-from mem0.configs.llms.deepseek import DeepSeekConfig
-from mem0.configs.llms.lmstudio import LMStudioConfig
-from mem0.configs.llms.ollama import OllamaConfig
-from mem0.configs.llms.openai import OpenAIConfig
-from mem0.configs.llms.vllm import VllmConfig
-from mem0.configs.rerankers.base import BaseRerankerConfig
-from mem0.configs.rerankers.cohere import CohereRerankerConfig
-from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
-from mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
-from mem0.configs.rerankers.llm import LLMRerankerConfig
-from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
-from mem0.embeddings.mock import MockEmbeddings
+from vendor.mem0.configs.embeddings.base import BaseEmbedderConfig
+from vendor.mem0.configs.llms.anthropic import AnthropicConfig
+from vendor.mem0.configs.llms.azure import AzureOpenAIConfig
+from vendor.mem0.configs.llms.base import BaseLlmConfig
+from vendor.mem0.configs.llms.deepseek import DeepSeekConfig
+from vendor.mem0.configs.llms.lmstudio import LMStudioConfig
+from vendor.mem0.configs.llms.ollama import OllamaConfig
+from vendor.mem0.configs.llms.openai import OpenAIConfig
+from vendor.mem0.configs.llms.vllm import VllmConfig
+from vendor.mem0.configs.rerankers.base import BaseRerankerConfig
+from vendor.mem0.configs.rerankers.cohere import CohereRerankerConfig
+from vendor.mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
+from vendor.mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
+from vendor.mem0.configs.rerankers.llm import LLMRerankerConfig
+from vendor.mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
+from vendor.mem0.embeddings.mock import MockEmbeddings
 
 
 def load_class(class_type):

--- a/vendor/mem0/vector_stores/azure_ai_search.py
+++ b/vendor/mem0/vector_stores/azure_ai_search.py
@@ -5,8 +5,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from mem0.memory.utils import extract_json
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.memory.utils import extract_json
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 try:
     from azure.core.credentials import AzureKeyCredential

--- a/vendor/mem0/vector_stores/azure_mysql.py
+++ b/vendor/mem0/vector_stores/azure_mysql.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     AZURE_IDENTITY_AVAILABLE = False
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/baidu.py
+++ b/vendor/mem0/vector_stores/baidu.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 try:
     import pymochow

--- a/vendor/mem0/vector_stores/cassandra.py
+++ b/vendor/mem0/vector_stores/cassandra.py
@@ -15,7 +15,7 @@ except ImportError:
         "Please install it using 'pip install cassandra-driver'"
     )
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/chroma.py
+++ b/vendor/mem0/vector_stores/chroma.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     raise ImportError("The 'chromadb' library is required. Please install it using 'pip install chromadb'.")
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/databricks.py
+++ b/vendor/mem0/vector_stores/databricks.py
@@ -14,8 +14,8 @@ from databricks.sdk.service.vectorsearch import (
     EmbeddingVectorColumn,
 )
 from pydantic import BaseModel
-from mem0.memory.utils import extract_json
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.memory.utils import extract_json
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/elasticsearch.py
+++ b/vendor/mem0/vector_stores/elasticsearch.py
@@ -9,8 +9,8 @@ except ImportError:
 
 from pydantic import BaseModel
 
-from mem0.configs.vector_stores.elasticsearch import ElasticsearchConfig
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.configs.vector_stores.elasticsearch import ElasticsearchConfig
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/faiss.py
+++ b/vendor/mem0/vector_stores/faiss.py
@@ -26,7 +26,7 @@ except ImportError:
         "or `pip install faiss-cpu` (depending on Python version)."
     )
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/langchain.py
+++ b/vendor/mem0/vector_stores/langchain.py
@@ -10,7 +10,7 @@ except ImportError:
         "The 'langchain_community' library is required. Please install it using 'pip install langchain_community'."
     )
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/milvus.py
+++ b/vendor/mem0/vector_stores/milvus.py
@@ -3,8 +3,8 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel
 
-from mem0.configs.vector_stores.milvus import MetricType
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.configs.vector_stores.milvus import MetricType
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 try:
     import pymilvus  # noqa: F401

--- a/vendor/mem0/vector_stores/mongodb.py
+++ b/vendor/mem0/vector_stores/mongodb.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     raise ImportError("The 'pymongo' library is required. Please install it using 'pip install pymongo'.")
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/vendor/mem0/vector_stores/neptune_analytics.py
+++ b/vendor/mem0/vector_stores/neptune_analytics.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     raise ImportError("langchain_aws is not installed. Please install it using pip install langchain_aws")
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/opensearch.py
+++ b/vendor/mem0/vector_stores/opensearch.py
@@ -9,8 +9,8 @@ except ImportError:
 
 from pydantic import BaseModel
 
-from mem0.configs.vector_stores.opensearch import OpenSearchConfig
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.configs.vector_stores.opensearch import OpenSearchConfig
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/pgvector.py
+++ b/vendor/mem0/vector_stores/pgvector.py
@@ -25,7 +25,7 @@ except ImportError:
             "Please install one of them using 'pip install psycopg[pool]' or 'pip install psycopg2'"
         )
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/pinecone.py
+++ b/vendor/mem0/vector_stores/pinecone.py
@@ -11,7 +11,7 @@ except ImportError:
         "Pinecone requires extra dependencies. Install with `pip install pinecone pinecone-text`"
     ) from None
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/qdrant.py
+++ b/vendor/mem0/vector_stores/qdrant.py
@@ -14,7 +14,7 @@ from qdrant_client.models import (
     VectorParams,
 )
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/redis.py
+++ b/vendor/mem0/vector_stores/redis.py
@@ -11,8 +11,8 @@ from redisvl.index import SearchIndex
 from redisvl.query import VectorQuery
 from redisvl.query.filter import Tag
 
-from mem0.memory.utils import extract_json
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.memory.utils import extract_json
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/s3_vectors.py
+++ b/vendor/mem0/vector_stores/s3_vectors.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 try:
     import boto3

--- a/vendor/mem0/vector_stores/supabase.py
+++ b/vendor/mem0/vector_stores/supabase.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     raise ImportError("The 'vecs' library is required. Please install it using 'pip install vecs'.")
 
-from mem0.configs.vector_stores.supabase import IndexMeasure, IndexMethod
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.configs.vector_stores.supabase import IndexMeasure, IndexMethod
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/upstash_vector.py
+++ b/vendor/mem0/vector_stores/upstash_vector.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 try:
     from upstash_vector import Index

--- a/vendor/mem0/vector_stores/valkey.py
+++ b/vendor/mem0/vector_stores/valkey.py
@@ -9,8 +9,8 @@ import valkey
 from pydantic import BaseModel
 from valkey.exceptions import ResponseError
 
-from mem0.memory.utils import extract_json
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.memory.utils import extract_json
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 

--- a/vendor/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/vendor/mem0/vector_stores/vertex_ai_vector_search.py
@@ -14,10 +14,10 @@ try:
 except ImportError:  # pragma: no cover - fallback for older LangChain versions
     from langchain.schema import Document  # type: ignore[no-redef]
 
-from mem0.configs.vector_stores.vertex_ai_vector_search import (
+from vendor.mem0.configs.vector_stores.vertex_ai_vector_search import (
     GoogleMatchingEngineConfig,
 )
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)

--- a/vendor/mem0/vector_stores/weaviate.py
+++ b/vendor/mem0/vector_stores/weaviate.py
@@ -17,7 +17,7 @@ from weaviate.classes.init import AdditionalConfig, Auth, Timeout
 from weaviate.classes.query import Filter, MetadataQuery
 from weaviate.util import get_valid_uuid
 
-from mem0.vector_stores.base import VectorStoreBase
+from vendor.mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Updates all internal imports in vendored mem0 to use `vendor.mem0.*` prefix
- Hardcodes version to avoid metadata lookup for pip package
- Fixes `No package metadata was found for mem0ai` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)