### PR TITLE
fix: use Dockerfile for backup service postgresql-client

### DIFF
--- a/backup_service/Dockerfile
+++ b/backup_service/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+# Install PostgreSQL client tools (pg_dump, psql)
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backup script
+COPY backup.py .
+
+# Expose health check port
+EXPOSE 8080
+
+# Run backup
+CMD ["python", "backup.py"]

--- a/backup_service/railway.toml
+++ b/backup_service/railway.toml
@@ -1,11 +1,8 @@
 [build]
-builder = "nixpacks"
-
-[build.nixpacks]
-aptPkgs = ["postgresql-client"]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "python backup.py"
 healthcheckPath = "/health"
 healthcheckTimeout = 30
 # Run as cron job - daily at 3:00 AM UTC


### PR DESCRIPTION
## Summary
Fixes postgresql-client not being installed by nixpacks.

Nixpacks `aptPkgs` config wasn't working properly on Railway - `psql` and `pg_dump` were missing.

## Changes
- Added `Dockerfile` with explicit `apt-get install postgresql-client`
- Updated `railway.toml` to use dockerfile builder

## Test Plan
- [ ] Deploy and verify `pg_dump` works
- [ ] Check backup completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)