### PR TITLE
fix: install PostgreSQL 18 client for mem0 backup

### DIFF
--- a/backup_service/Dockerfile
+++ b/backup_service/Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.12-slim
 
-# Install PostgreSQL client tools (pg_dump, psql)
+# Install PostgreSQL 18 client from official PostgreSQL repo
+# This ensures we have pg_dump compatible with PG 18 servers
 RUN apt-get update && apt-get install -y \
-    postgresql-client \
+    curl \
+    gnupg \
+    lsb-release \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y postgresql-client-18 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory


### PR DESCRIPTION
## Summary
mem0 database runs PostgreSQL 18.1, but the default `postgresql-client` package only includes pg_dump 17.

## Fix
Install PostgreSQL 18 client from the official PostgreSQL apt repository.

## Error Fixed
```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 18.1; pg_dump version: 17.6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)