### PR TITLE
fix: add missing capabilities for Google, email, and local file tools

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -254,7 +254,21 @@ def get_all_tools(include_docker: bool = True) -> list[dict]:
         return []
 
     registry = get_registry()
-    capabilities = {"docker": include_docker}
+
+    # Build capabilities dict based on what's configured
+    capabilities = {
+        "docker": include_docker,
+        "files": True,  # Local files always available (has default path)
+    }
+
+    # Google OAuth - check if credentials are configured
+    if os.getenv("GOOGLE_CLIENT_ID") and os.getenv("GOOGLE_CLIENT_SECRET"):
+        capabilities["google_oauth"] = True
+
+    # Email - check if credentials are configured
+    if os.getenv("CLARA_EMAIL_ADDRESS") and os.getenv("CLARA_EMAIL_PASSWORD"):
+        capabilities["email"] = True
+
     return registry.get_tools(
         platform="discord", capabilities=capabilities, format="openai"
     )


### PR DESCRIPTION
## Summary
Fixes tool registration so Google Workspace, email, and local file tools are properly included when their respective credentials are configured.

## Problem
The `get_all_tools()` function was only passing `{"docker": include_docker}` as capabilities to the registry. Since Google tools require `google_oauth`, email tools require `email`, and local file tools require `files` capabilities, they were all being filtered out even when properly configured.

## Fix
Now builds capabilities dict based on what's actually configured:
- `files`: Always `True` (local files have a default path)
- `google_oauth`: `True` when `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set
- `email`: `True` when `CLARA_EMAIL_ADDRESS` and `CLARA_EMAIL_PASSWORD` are set

## Test plan
- [ ] Verify Google tools appear in tool list when OAuth is configured
- [ ] Verify email tools appear when email credentials are set
- [ ] Verify local file tools are always available
- [ ] Confirm tools still work correctly after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)