### PR TITLE
fix: handle AttributeError when tool returns JSON array

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -2094,7 +2094,7 @@ Note: Messages prefixed with [Username] are from other users. Address people by 
                         tool_output = (
                             "OAuth authorization link sent to user via Discord button."
                         )
-                except (json.JSONDecodeError, KeyError, TypeError):
+                except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
                     pass  # Not a button response, use as-is
 
                 # Add tool result to conversation


### PR DESCRIPTION
## Summary
Tools like `google_sheets_read` and `google_drive_list` return JSON arrays. When the Discord button check tries to call `.get()` on an array, it raises `AttributeError` (lists don't have `.get()`).

## Fix
Added `AttributeError` to the exception handler:
```python
except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
    pass  # Not a button response, use as-is
```

## Test plan
- [ ] Call a Google tool that returns a JSON array
- [ ] Verify no crash, tool output used as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)