### PR TITLE
feat: add time-aware context for conversation continuity

### DIFF
--- a/config/bot.py
+++ b/config/bot.py
@@ -37,6 +37,13 @@ Skills:
 - Memory continuity & pattern insight
 - Direct communication drafting
 
+Conversational Continuity:
+- When time has passed since the last message, acknowledge it naturally like catching up with a friend
+- If the user said they were doing something (bath time, shower, errand), assume it completed and react
+- "How'd it go?" is better than "I see 2 hours have passed"
+- Don't announce time gaps explicitly - just respond with natural awareness
+- If they said "brb" and now they're back, welcome them back casually
+
 Use the context below to inform responses. When contradictions exist, prefer newer information."""
 
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -884,16 +884,91 @@ class ClaraDiscordBot(discord.Client):
         llm = make_llm()
         return llm(messages)
 
+    def _format_time_gap(self, last_time: datetime | None) -> str | None:
+        """Format time gap since last message in human-readable form.
+
+        Returns None if gap is < 5 minutes (not worth mentioning).
+        """
+        if last_time is None:
+            return None
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        # Handle timezone-aware datetimes
+        if last_time.tzinfo is not None:
+            last_time = last_time.replace(tzinfo=None)
+
+        delta = now - last_time
+        total_seconds = delta.total_seconds()
+
+        if total_seconds < 300:  # < 5 min, not worth mentioning
+            return None
+        elif total_seconds < 3600:  # < 1 hour
+            minutes = int(total_seconds // 60)
+            return f"{minutes} minutes ago"
+        elif total_seconds < 86400:  # < 1 day
+            hours = int(total_seconds // 3600)
+            return f"{hours} hour{'s' if hours != 1 else ''} ago"
+        else:
+            days = int(total_seconds // 86400)
+            return f"{days} day{'s' if days != 1 else ''} ago"
+
+    def _extract_departure_context(self, last_user_message: str | None) -> str | None:
+        """Extract what user said they were going to do from their last message.
+
+        Looks for patterns like:
+        - "going to [verb]"
+        - "brb [doing something]"
+        - "heading out to [activity]"
+        - "gotta [do something]"
+
+        Returns a brief context or None if no departure detected.
+        """
+        if not last_user_message:
+            return None
+
+        import re
+
+        msg = last_user_message.lower().strip()
+
+        # Common departure patterns
+        patterns = [
+            r"(?:going to|gonna|gotta|about to|heading to|off to)\s+(.+?)(?:\.|!|$)",
+            r"brb\s*[,:]?\s*(.+?)(?:\.|!|$)",
+            r"(?:be right back|be back)\s*[,:]?\s*(.+?)(?:\.|!|$)",
+            r"(?:stepping away|stepping out)\s*(?:to|for)?\s*(.+?)(?:\.|!|$)",
+            r"(?:need to|have to|gotta)\s+(.+?)(?:\.|!|$)",
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, msg, re.IGNORECASE)
+            if match:
+                activity = match.group(1).strip()
+                # Clean up and limit length
+                if len(activity) > 100:
+                    activity = activity[:100] + "..."
+                if activity:
+                    return activity
+
+        return None
+
     def _build_discord_context(
         self,
         message: DiscordMessage,
         user_mems: list[str],
         proj_mems: list[str],
         is_dm: bool = False,
+        recent_msgs: list | None = None,
     ) -> str:
         """Build Discord-specific system context.
 
         Organized for prompt caching: static content first, dynamic content last.
+
+        Args:
+            message: Current Discord message
+            user_mems: User memories from mem0
+            proj_mems: Project memories from mem0
+            is_dm: Whether this is a DM conversation
+            recent_msgs: Recent messages from the session (for time gap tracking)
         """
         # === STATIC CONTENT (cacheable) ===
         static_parts = [
@@ -924,15 +999,31 @@ You have persistent memory via mem0. Use memories naturally without announcing "
         guild_name = message.guild.name if message.guild else "Direct Message"
         current_time = _get_current_time()
 
+        # Calculate time gap and departure context from recent messages
+        time_gap_line = ""
+        departure_line = ""
+        if recent_msgs:
+            # Find last user message (not from assistant)
+            user_msgs = [m for m in recent_msgs if m.role == "user"]
+            if user_msgs:
+                last_user_msg = user_msgs[-1]
+                time_gap = self._format_time_gap(last_user_msg.created_at)
+                if time_gap:
+                    time_gap_line = f"\nLast interaction: {time_gap}"
+                    # Check if user mentioned what they were doing
+                    departure_ctx = self._extract_departure_context(last_user_msg.content)
+                    if departure_ctx:
+                        departure_line = f"\nUser was: {departure_ctx}"
+
         if is_dm:
             dynamic_context = f"""## Current Context
-Time: {current_time}
+Time: {current_time}{time_gap_line}{departure_line}
 Environment: Private DM with {display_name} (one-on-one)
 User: {display_name} (@{username}, discord-{user_id})
 Memories: {len(user_mems)} user, {len(proj_mems)} project"""
         else:
             dynamic_context = f"""## Current Context
-Time: {current_time}
+Time: {current_time}{time_gap_line}{departure_line}
 Environment: {guild_name} server, #{channel_name} (shared channel)
 Speaker: {display_name} (@{username}, discord-{user_id})
 Memories: {len(user_mems)} user, {len(proj_mems)} project
@@ -1375,7 +1466,7 @@ Note: Messages prefixed with [Username] are from other users. Address people by 
 
                 # Inject Discord-specific context after the base system prompt
                 discord_context = self._build_discord_context(
-                    message, user_mems, proj_mems, is_dm
+                    message, user_mems, proj_mems, is_dm, recent_msgs
                 )
                 # Insert as second system message (after Clara's persona)
                 system_msg = {"role": "system", "content": discord_context}


### PR DESCRIPTION
## Summary
Add time gap awareness to Discord conversations so Clara naturally acknowledges when users return after being away.

## Problem
When a user says "going to give muumuu a bath, brb" and returns 2 hours later with "finally done", Clara responded without acknowledging the gap or what the user was doing. A natural response would be "How'd bedtime go?" or "Took a while, huh?"

## Solution

### 1. Time Gap Tracking (`discord_bot.py`)
- `_format_time_gap()` - Formats elapsed time in human-readable form (e.g., "2 hours ago")
- `_extract_departure_context()` - Detects patterns like "brb", "going to", "heading out to"
- Only includes time gap when > 5 minutes has passed (to avoid noise)

### 2. Context Injection
The dynamic context block now includes:
```
Time: Thursday, January 2nd at 4:30 PM
Last interaction: 2 hours ago
User was: give muumuu a bath
```

### 3. Personality Guidance (`config/bot.py`)
Added "Conversational Continuity" section to guide natural responses:
- Acknowledge time gaps like catching up with a friend
- Assume mentioned activities completed
- "How'd it go?" is better than "I see 2 hours have passed"

## Departure Patterns Detected
- "going to [verb]" / "gonna [verb]"
- "brb [doing something]"
- "be right back [reason]"
- "stepping away to [activity]"
- "need to / have to / gotta [do something]"

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)