### PR TITLE
fix: use base model when MODEL_TIER is not set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Optional tier-specific model overrides:
 - `NANOGPT_MODEL_HIGH`, `NANOGPT_MODEL_MID`, `NANOGPT_MODEL_LOW`
 - `CUSTOM_OPENAI_MODEL_HIGH`, `CUSTOM_OPENAI_MODEL_MID`, `CUSTOM_OPENAI_MODEL_LOW`
 - `ANTHROPIC_MODEL_HIGH`, `ANTHROPIC_MODEL_MID`, `ANTHROPIC_MODEL_LOW`
-- `MODEL_TIER` - Default tier when not specified (default: "mid")
+- `MODEL_TIER` - Default tier when not specified. If not set, uses the base model (e.g., `ANTHROPIC_MODEL`). Set to "high", "mid", or "low" to enable tier-based defaults.
 - `AUTO_TIER_SELECTION` - Enable automatic tier selection based on message complexity (default: false)
 
 **Auto Tier Selection:**


### PR DESCRIPTION
## Summary
- Fixed bug where `MODEL_TIER` defaulting to "mid" ignored the base `ANTHROPIC_MODEL` setting
- `get_current_tier()` now returns `None` when `MODEL_TIER` is not explicitly set
- All LLM creation functions fall back to the base model when no tier is configured

## Test plan
- [ ] Set only `ANTHROPIC_MODEL=claude-opus-4-5` without `MODEL_TIER` → should use Opus
- [ ] Set `MODEL_TIER=mid` → should use `ANTHROPIC_MODEL_MID`
- [ ] Use `!high` prefix → should still override to high tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)