### PR TITLE
feat: Discord channel log mirroring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,14 @@ poetry run python scripts/migrate_to_postgres.py --all
 - `DISCORD_CHANNEL_HISTORY_LIMIT` - Max messages to fetch from channel (default: 50)
 - `DISCORD_MONITOR_PORT` - Monitor dashboard port (default: 8001)
 - `DISCORD_MONITOR_ENABLED` - Enable monitor dashboard (default: true)
+- `DISCORD_LOG_CHANNEL_ID` - Channel ID to mirror console logs to (optional)
+
+**Console Log Mirroring:**
+When `DISCORD_LOG_CHANNEL_ID` is set, all console log output is mirrored to the specified Discord channel. Each log line becomes a separate message. Special events are highlighted:
+- 🟢 Bot started
+- 🔴 Bot shutting down
+- 🟡 Bot disconnected
+- 🔄 Bot reconnected/resumed
 
 **Stop Phrases:**
 Users can interrupt Clara mid-task by sending a stop phrase (e.g., "@Clara stop" or "@Clara nevermind"). This immediately cancels the current task and clears any queued requests for that channel. Useful when Clara is taking too long or working on the wrong thing.


### PR DESCRIPTION
## Summary

- Adds `DiscordLogHandler` class that queues log messages and sends them to a Discord channel
- Each console log line becomes a separate Discord message (wrapped in backticks for monospace)
- Respects Discord rate limits with batched sending (~5 messages/second)
- Lifecycle events highlighted with emoji: 🟢 start, 🔴 shutdown, 🟡 disconnect, 🔄 reconnect

## Configuration

Set `DISCORD_LOG_CHANNEL_ID` to the channel ID where logs should be mirrored.

## Test plan

- [ ] Set `DISCORD_LOG_CHANNEL_ID` to a test channel
- [ ] Start bot, verify "🟢 Bot started" message appears
- [ ] Verify regular log messages appear as code-formatted messages
- [ ] Stop bot (Ctrl+C), verify "🔴 Bot shutting down" appears
- [ ] Test disconnect/reconnect by briefly cutting network

🤖 Generated with [Claude Code](https://claude.com/claude-code)